### PR TITLE
Allow for separate building and executing of YCSB

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -114,7 +114,11 @@ OPTIONS = {
     "-threads n"     : "Number of client threads (default: 1)",
     "-cp path"       : "Additional Java classpath entries",
     "-jvm-args args" : "Additional arguments to the JVM",
+    "-build-only"    : "Only build, don't run YCSB",
+    "-force-rebuild" : "Force a clean rebuild"
 }
+
+CP_FILE = 'cp.txt'
 
 def usage():
     output = io.BytesIO()
@@ -203,24 +207,34 @@ def is_distribution():
     # If there's a top level pom, we're a source checkout. otherwise a dist artifact
     return "pom.xml" not in os.listdir(get_ycsb_home())
 
+def get_classpath_from_file(binding, filename):
+    if not os.path.isfile(filename):
+        error("Attempting to read classpath from file failed. File ./"
+             + binding + "/" + filename + " does not exist.")
+        sys.exit(1)
+
+    f = open(binding + "/" + filename, 'r')
+    cp_str = f.read()
+    f.close()
+
+    return cp_str[len("classpath="):]
+
 # Run the maven dependency plugin to get the local jar paths.
 # presumes maven can run, so should only be run on source checkouts
 # will invoke the 'package' goal for the given binding in order to resolve intra-project deps
 # presumes maven properly handles system-specific path separators
 # Given module is full module name eg. 'core' or 'couchbase-binding'
-def get_classpath_from_maven(module):
+def get_classpath_from_maven(module, binding, outputfile):
     try:
         debug("Running 'mvn -pl com.yahoo.ycsb:" + module + " -am package -DskipTests "
               "dependency:build-classpath -DincludeScope=compile -Dmdep.outputFilterFile=true'")
-        mvn_output = check_output(["mvn", "-pl", "com.yahoo.ycsb:" + module,
-                                   "-am", "package", "-DskipTests",
-                                   "dependency:build-classpath",
-                                   "-DincludeScope=compile",
-                                   "-Dmdep.outputFilterFile=true"])
-        # the above outputs a "classpath=/path/tojar:/path/to/other/jar" for each module
-        # the last module will be the datastore binding
-        line = [x for x in mvn_output.splitlines() if x.startswith("classpath=")][-1:]
-        return line[0][len("classpath="):]
+        check_output(["mvn", "-pl", "com.yahoo.ycsb:" + module,
+                      "-am", "package", "-DskipTests",
+                      "dependency:build-classpath",
+                      "-DincludeScope=compile",
+                      "-Dmdep.outputFilterFile=true",
+                      "-Dmdep.outputFile=" + outputfile])
+        return get_classpath_from_file(binding, outputfile)
     except subprocess.CalledProcessError, err:
         error("Attempting to generate a classpath from Maven failed "
               "with return code '" + str(err.returncode) + "'. The output from "
@@ -244,6 +258,10 @@ def main():
                    help="""Command to run.""")
     p.add_argument("database", choices=sorted(DATABASES),
                    help="""Database to test.""")
+    p.add_argument("-build-only", dest="build_only", action="store_true",
+                   help="""Only build, don't run YCSB""")
+    p.add_argument("-force-rebuild", dest="force_rebuild", action="store_true",
+                   help="""Force a clean rebuild""")
     args, remaining = p.parse_known_args()
     ycsb_home = get_ycsb_home()
 
@@ -312,8 +330,12 @@ def main():
         db_location = "core" if (binding == "basic" or binding == "basicts") else binding
         project = "core" if (binding == "basic" or binding == "basicts") else binding + "-binding"
         db_dir = os.path.join(ycsb_home, db_location)
-        # goes first so we can rely on side-effect of package
-        maven_says = get_classpath_from_maven(project)
+        # goes first so we can rely on side-effect of 
+        cp_is_cached = os.path.isfile(CP_FILE)
+        if args.force_rebuild or not cp_is_cached:
+            maven_says = get_classpath_from_maven(project, binding, CP_FILE)
+        elif cp_is_cached:
+            maven_says = get_classpath_from_file(binding, CP_FILE)
         # TODO when we have a version property, skip the glob
         cp = find_jars(os.path.join(db_dir, "target"),
                        project + "*.jar")
@@ -331,7 +353,9 @@ def main():
         ycsb_command.append(command)
     print >> sys.stderr, " ".join(ycsb_command)
     try:
-        return subprocess.call(ycsb_command)
+        if not args.build_only:
+            return subprocess.call(ycsb_command)
+        return 0
     except OSError as e:
         if e.errno == errno.ENOENT:
             error('Command failed. Is java installed and on your PATH?')

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -119,7 +119,6 @@ OPTIONS = {
     "-threads n"     : "Number of client threads (default: 1)",
     "-cp path"       : "Additional Java classpath entries",
     "-jvm-args args" : "Additional arguments to the JVM",
-    "-build-only"    : "Only build, don't run YCSB",
     "-force-rebuild" : "Force a clean rebuild"
 }
 

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -327,7 +327,7 @@ def main():
         cp.extend(find_jars(os.path.join(db_dir, "lib")))
     else:
         warn("Running against a source checkout. In order to get our runtime "
-             "dependencies we'll have to invoke Maven. Depending on the state "
+             "dependencies we may have to invoke Maven. Depending on the state "
              "of your system, this may take ~30-45 seconds")
         db_location = "core" if (binding == "basic" or binding == "basicts") else binding
         project = "core" if (binding == "basic" or binding == "basicts") else binding + "-binding"
@@ -338,10 +338,11 @@ def main():
             return 0
 
         # goes first so we can rely on side-effect of package
-        cp_is_cached = os.path.isfile(CP_FILE)
+        cp_is_cached = os.path.isfile(binding + "/" + CP_FILE)
         if args.force_rebuild or not cp_is_cached:
             maven_says = get_classpath_from_maven(project, binding, CP_FILE)
         elif cp_is_cached:
+            debug("Cached runtime dependencies found. Skipping running Maven.")
             maven_says = get_classpath_from_file(binding, CP_FILE)
 
         # TODO when we have a version property, skip the glob

--- a/bin/ycsb
+++ b/bin/ycsb
@@ -48,6 +48,11 @@ COMMANDS = {
         "description" : "Execute the transaction phase",
         "main"        : "com.yahoo.ycsb.Client",
     },
+    "build" : {
+        "command"     : "",
+        "description" : "Build YCSB without executing (source checkout only)",
+        "main"        : ""
+    }
 }
 
 DATABASES = {
@@ -258,8 +263,6 @@ def main():
                    help="""Command to run.""")
     p.add_argument("database", choices=sorted(DATABASES),
                    help="""Database to test.""")
-    p.add_argument("-build-only", dest="build_only", action="store_true",
-                   help="""Only build, don't run YCSB""")
     p.add_argument("-force-rebuild", dest="force_rebuild", action="store_true",
                    help="""Force a clean rebuild""")
     args, remaining = p.parse_known_args()
@@ -330,12 +333,18 @@ def main():
         db_location = "core" if (binding == "basic" or binding == "basicts") else binding
         project = "core" if (binding == "basic" or binding == "basicts") else binding + "-binding"
         db_dir = os.path.join(ycsb_home, db_location)
-        # goes first so we can rely on side-effect of 
+
+        if args.command == "build":
+            get_classpath_from_maven(project, binding, CP_FILE)
+            return 0
+
+        # goes first so we can rely on side-effect of package
         cp_is_cached = os.path.isfile(CP_FILE)
         if args.force_rebuild or not cp_is_cached:
             maven_says = get_classpath_from_maven(project, binding, CP_FILE)
         elif cp_is_cached:
             maven_says = get_classpath_from_file(binding, CP_FILE)
+
         # TODO when we have a version property, skip the glob
         cp = find_jars(os.path.join(db_dir, "target"),
                        project + "*.jar")
@@ -353,9 +362,7 @@ def main():
         ycsb_command.append(command)
     print >> sys.stderr, " ".join(ycsb_command)
     try:
-        if not args.build_only:
-            return subprocess.call(ycsb_command)
-        return 0
+        return subprocess.call(ycsb_command)
     except OSError as e:
         if e.errno == errno.ENOENT:
             error('Command failed. Is java installed and on your PATH?')


### PR DESCRIPTION
In perfrunner we run a new instance of YCSB for each bucket we want to access in our tests. For tests with many buckets (e.g. 20) we often hit problems as many invocations of YCSB all try to simultaneously build before executing (specifically, they run the `mvn -pl com.yahoo.ycsb:<binding> -am package -DskipTests dependency:build-classpath -DincludeScope=compile -Dmdep.outputFilterFile=true` command).

To alleviate such problems, this PR adds a new `build` command to `bin/ycsb`, which allows one to only build (without executing) YCSB and saves the necessary classpath generated in a file. The execution commands have been modified to read the classpath from the generated file if it exists, instead of rerunning the maven command. The option to force the maven command to be run has been added in the form of the `-force-rebuild` flag.

Now, instead of having each new invocation of YCSB try to run the maven command at the same time (redundantly and with the potential for conflict), we can just run the command once and then invoke YCSB multiple times.