### PR TITLE
Fix bug when checking whether classpath file exists

### DIFF
--- a/bin/ycsb
+++ b/bin/ycsb
@@ -205,12 +205,13 @@ def is_distribution():
     return "pom.xml" not in os.listdir(get_ycsb_home())
 
 def get_classpath_from_file(binding, filename):
-    if not os.path.isfile(filename):
+    classpath_file = binding + "/" + filename
+    if not os.path.isfile(classpath_file):
         error("Attempting to read classpath from file failed. File ./"
-             + binding + "/" + filename + " does not exist.")
+             + classpath_file + " does not exist.")
         sys.exit(1)
 
-    f = open(binding + "/" + filename, 'r')
+    f = open(classpath_file, 'r')
     cp_str = f.read()
     f.close()
 


### PR DESCRIPTION
When reading the classpath from a file (after having previously ran `ycsb build`) the check for whether the file exists was slightly wrong.